### PR TITLE
Add GitLab Pipelines by puzl.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ As always, please feel free to make Pull Requests to add additional offerings th
 
 [Frolic](https://github.com/FrolicOrg/Frolic) Backend service to build customer facing dashboards 10x faster. Written in Rust.
 
+[GitLab Pipelines by puzl.cloud](https://gitlab-pipelines.puzl.cloud/) - Run your GitLab CI/CD faster and cheaper. Focus on CI/CD workflows while we handle your GitLab runners and pipeline jobs.
+
 ## Sales
 
 [HubSpot](https://www.hubspot.com) - Generate leads, close deals & manage your pipeline with the Hubspot growth stack.


### PR DESCRIPTION
[Puzl](https://puzl.cloud) is a modern cloud platform focusing on cost-effective runtime. You can run cloud workloads and pay for their pure CPU and memory consumption, not for the idle of cloud instances. In this request, I submit our new SaaS service for running GitLab CI/CD pipelines.