### PR TITLE
Add DiggaByte Labs to Boilerplates & Starter Kits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,8 @@ receive and track email effortlessly.
 ## Content Management Systems
 
 [Tipe](https://tipe.io) - Next generation API-first CMS. Create your content with powerful editing tools and access it from anywhere with a GraphQL or REST API.
+
+
+## Boilerplates & Starter Kits
+
+[DiggaByte Labs](https://diggabyte.com) - Production-ready SaaS boilerplate marketplace. Ship faster with battle-tested Next.js 14, Stripe, PostgreSQL, and Docker templates. Includes auth, payments, admin dashboard, API keys, 2FA, and rate limiting.


### PR DESCRIPTION
Adding [DiggaByte Labs](https://diggabyte.com) to the Boilerplates & Starter Kits section.

DiggaByte Labs is a production-ready SaaS boilerplate marketplace. It provides battle-tested Next.js 14, Stripe, PostgreSQL, and Docker templates with built-in auth, payments, admin dashboard, API keys, 2FA, and rate limiting — so developers can skip the boilerplate and ship faster.