### PR TITLE
Add Arch Tools — 61 AI tools API platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ As always, please feel free to make Pull Requests to add additional offerings th
 
 [GitLab Pipelines by puzl.cloud](https://gitlab-pipelines.puzl.cloud/) - Run your GitLab CI/CD faster and cheaper. Focus on CI/CD workflows while we handle your GitLab runners and pipeline jobs.
 
+[Arch Tools](https://archtools.dev) - The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible. [Docs](https://archtools.dev/docs) | [Directory](https://archtools.dev/directory) | [GitHub](https://github.com/Deesmo/Arch-AI-Tools)
+
 ## Sales
 
 [HubSpot](https://www.hubspot.com) - Generate leads, close deals & manage your pipeline with the Hubspot growth stack.


### PR DESCRIPTION
Adds Arch Tools to Infrastructure, Engineering & APIs. 61 AI tools via REST + MCP protocol. Free tier: 100 credits/month. https://archtools.dev